### PR TITLE
Add a "skip $x lines" feature.

### DIFF
--- a/src/main/groovy/org/elasticsearch/river/csv/Configuration.groovy
+++ b/src/main/groovy/org/elasticsearch/river/csv/Configuration.groovy
@@ -19,6 +19,8 @@ class Configuration {
 
     boolean firstLineIsHeader = false
 
+    int skipLines = 0
+
     List<Object> csvFields
     TimeValue poll
 
@@ -41,6 +43,7 @@ class Configuration {
             Map<String, Object> csvSettings = (Map<String, Object>) settings.settings().get(CSV_FILE)
 
             firstLineIsHeader = nodeBooleanValue(csvSettings.get(CSV_FILE_IS_HEADER, false))
+            skipLines = nodeIntegerValue(csvSettings.get(SKIP_X_LINES, 0))
             folderName = nodeStringValue(csvSettings.get(FOLDER), null)
             filenamePattern = nodeStringValue(csvSettings.get(FILENAME_PATTERN), FILENAME_PATTERN_VALUE)
             csvFields = extractRawValues(FIELDS, csvSettings)

--- a/src/main/groovy/org/elasticsearch/river/csv/Constants.groovy
+++ b/src/main/groovy/org/elasticsearch/river/csv/Constants.groovy
@@ -8,6 +8,7 @@ class Constants {
     static class CSV {
 
         static final String CSV_FILE_IS_HEADER = 'first_line_is_header'
+        static final String SKIP_X_LINES = 'ignore_first_lines'
         static final String FOLDER = 'folder'
 
         static final String FILENAME_PATTERN = 'filename_pattern'


### PR DESCRIPTION
Here's the usecase for this:
![csv](https://f.cloud.github.com/assets/113178/2350994/43e037f2-a577-11e3-9a69-0865722ce138.png)

I have a horrible blackbox piece of software which generates call detail records in CSV format, and uploads them over ftp to an ftp server. I have absolutely no way to control the CSVs it generates, apart from manipulating them after the fact.

This sucks, because elasticsearch-river-csv is the perfect way to index this data, but if I were to use the river plugin as-is, I'd end up indexing a bunch of bogus documents with the value of "INTEGER" and such.

In this pull request, I've added a feature to ignore the first $x lines of a csv. With it, I can use an river with a _meta of:

```
{
    "type" : "csv",
    "csv_file" : {
        "folder" : "/tmp/csv",
        "first_line_is_header":"true",
        "ignore_first_lines": 1,
        "poll": "1m"
    }
}
```

With this config, first_line_is_header will offset ignore_first_lines; so the first line AFTER the header is skipped, and only the relevant data is inserted. Likewise, if `"first_line_is_header":"false"` is set, ignore_first_lines will ignore the very first line of the document.

Anyway, I just thought I'd push this back upstream. Feel free to reject this, I know it's of limited usefulness, but it would certainly be nice if I didn't have to maintain my own patchset against your code for this.
