### PR TITLE
Add a 'field_id_include' flag to still include the id field in the source even if 'field_id' is used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The CSV river import data from CSV files and index it.
 	        "escape_character" : ";",
 	        "quote_character" : "'",
             "field_id" : "id",
+            "field_id_include" : "false",
             "field_timestamp" : "imported_at",
             "concurrent_requests" : "1",
             "charset" : "UTF-8",

--- a/src/main/groovy/org/agileworks/elasticsearch/river/csv/Configuration.groovy
+++ b/src/main/groovy/org/agileworks/elasticsearch/river/csv/Configuration.groovy
@@ -32,6 +32,7 @@ class Configuration {
     int bulkThreshold
     int concurrentRequests
     String idField
+    boolean idFieldInclude = false
     String timestampField
 
     String scriptBeforeAll
@@ -56,6 +57,7 @@ class Configuration {
             separator = nodeStringValue(csvSettings.get(Constants.CSV.FIELD_SEPARATOR), String.valueOf(',')).charAt(0)
             quoteCharacter = nodeStringValue(csvSettings.get(Constants.CSV.QUOTE_CHARACTER), String.valueOf('\"')).charAt(0)
             idField = nodeStringValue(csvSettings.get(Constants.CSV.FIELD_ID), 'id')
+            idFieldInclude = nodeBooleanValue(csvSettings.get(Constants.CSV.FIELD_ID_INCLUDE, false))
             timestampField = nodeStringValue(csvSettings.get(Constants.CSV.FIELD_TIMESTAMP), null)
             concurrentRequests = nodeIntegerValue(csvSettings.get(Constants.CSV.CONCURRENT_REQUESTS), 1)
 

--- a/src/main/groovy/org/agileworks/elasticsearch/river/csv/Constants.groovy
+++ b/src/main/groovy/org/agileworks/elasticsearch/river/csv/Constants.groovy
@@ -26,6 +26,7 @@ class Constants {
         static final String FIELD_SEPARATOR = 'field_separator'
         static final String QUOTE_CHARACTER = 'quote_character'
         static final String FIELD_ID = 'field_id'
+        static final String FIELD_ID_INCLUDE = 'field_id_include'
         static final String FIELD_TIMESTAMP = 'field_timestamp'
 
         static final String CHARSET = 'charset'

--- a/src/main/groovy/org/agileworks/elasticsearch/river/csv/OpenCSVFileProcessor.groovy
+++ b/src/main/groovy/org/agileworks/elasticsearch/river/csv/OpenCSVFileProcessor.groovy
@@ -68,7 +68,7 @@ class OpenCSVFileProcessor implements FileProcessor {
         int position = 0
         for (Object fieldName : config.csvFields) {
 
-            if (fieldName != config.idField) {
+            if (config.idFieldInclude || fieldName != config.idField) {
                 builder.field((String) fieldName, line[position])
             }
 

--- a/src/test/groovy/org/agileworks/elasticsearch/river/csv/ConfigurationTest.groovy
+++ b/src/test/groovy/org/agileworks/elasticsearch/river/csv/ConfigurationTest.groovy
@@ -79,6 +79,7 @@ class ConfigurationTest extends Specification {
         config.filenamePattern
         !config.folderName
         config.idField
+        !config.idFieldInclude
         config.indexName
         config.poll
         config.quoteCharacter

--- a/src/test/groovy/org/agileworks/elasticsearch/river/csv/OpenCSVFileProcessorTest.groovy
+++ b/src/test/groovy/org/agileworks/elasticsearch/river/csv/OpenCSVFileProcessorTest.groovy
@@ -94,6 +94,7 @@ class OpenCSVFileProcessorTest extends Specification {
 
         configuration.firstLineIsHeader = true
         configuration.idField = idColumnName
+        configuration.idFieldInclude = idColumnInclude
         configuration.charset = Charset.forName(charset)
         configuration.separator = separator
 
@@ -123,10 +124,13 @@ class OpenCSVFileProcessorTest extends Specification {
 
         where:
 
-        idColumnName    | fileName                         | idValue            | charset    | separator | body
-        'id'            | 'test_1_id_column'               | ['1', '2']         | 'UTF-8'    | ','       | DEFAULT_BODIES
-        'ProductNumber' | 'test_1_ProductNumber_id_column' | ['223', '229']     | 'UTF-8'    | ','       | DEFAULT_BODIES
-        'ProductNumber' | 'turkish_encoding'               | ['69377', '69379'] | 'UTF-16LE' | ';'       | TURKISH_BODIES
+        idColumnName    | idColumnInclude | fileName                         | idValue            | charset    | separator | body
+        'id'            | false           | 'test_1_id_column'               | ['1', '2']         | 'UTF-8'    | ','       | DEFAULT_BODIES
+        'ProductNumber' | false           | 'test_1_ProductNumber_id_column' | ['223', '229']     | 'UTF-8'    | ','       | DEFAULT_BODIES
+        'ProductNumber' | false           | 'turkish_encoding'               | ['69377', '69379'] | 'UTF-16LE' | ';'       | TURKISH_BODIES
+        'id'            | true            | 'test_1_id_column'               | ['1', '2']         | 'UTF-8'    | ','       | ['{"id":"1","Year":"1997","Make":"Ford","Model":"E350"}', '{"id":"2","Year":"2000","Make":"Mercury","Model":"Cougar"}']
+        'ProductNumber' | true            | 'test_1_ProductNumber_id_column' | ['223', '229']     | 'UTF-8'    | ','       | ['{"ProductNumber":"223","Year":"1997","Make":"Ford","Model":"E350"}', '{"ProductNumber":"229","Year":"2000","Make":"Mercury","Model":"Cougar"}']
+        'ProductNumber' | true            | 'turkish_encoding'               | ['69377', '69379'] | 'UTF-16LE' | ';'       | ['{"ProductNumber":"69377","Title":"Decortie Labirent Kitaplık - Venge","":""}', '{"ProductNumber":"69379","Title":"Erciyes Dağı - Kapadokya Tablosu RMB-237 - 190x120 cm","":""}']
     }
 
     def "process file w/o header"() {


### PR DESCRIPTION
I came across a need to designate a column as the id field, while also needing to retain it in the source.

I added a 'field_id_include' flag that, when true, will retain the id column in the source.
If 'field_id_include' is false, it will behave as before and not include the id column in the source.
If 'field_id' is not set, then the 'field_id_include' flag will have no effect.