### PR TITLE
After import, the file remained open, preventing a rename to .imported.

### DIFF
--- a/src/main/groovy/org/agileworks/elasticsearch/river/csv/OpenCSVFileProcessor.groovy
+++ b/src/main/groovy/org/agileworks/elasticsearch/river/csv/OpenCSVFileProcessor.groovy
@@ -34,25 +34,31 @@ class OpenCSVFileProcessor implements FileProcessor {
         BOMInputStream bomInputStream = new BOMInputStream(new FileInputStream(file), false, AVAILABLE_BOMS)
 
         CSVReader reader = new CSVReader(new InputStreamReader(bomInputStream, config.charset), config.separator.charValue(), config.quoteCharacter, config.escapeCharacter)
+        try {
 
-        String[] nextLine
+            String[] nextLine
 
-        while ((nextLine = reader.readNext()) != null) {
+            while ((nextLine = reader.readNext()) != null) {
 
-            if (linesCount == 0 && config.firstLineIsHeader) {
+                if (linesCount == 0 && config.firstLineIsHeader) {
 
-                config.csvFields = Arrays.asList(nextLine)
+                    config.csvFields = Arrays.asList(nextLine)
 
-            } else if (nextLine.length > 0 && !(nextLine.length == 1 && nextLine[0].trim().equals(''))) {
+                } else if (nextLine.length > 0 && !(nextLine.length == 1 && nextLine[0].trim().equals(''))) {
 
-                try {
-                    processDataLine(nextLine)
-                } catch (Exception e) {
-                    listener.onErrorAndContinue(e, "Error has occured during processing file '$file.name' , skipping line: '${nextLine}' and continue in processing")
+                    try {
+                        processDataLine(nextLine)
+                    } catch (Exception e) {
+                        listener.onErrorAndContinue(e, "Error has occured during processing file '$file.name' , skipping line: '${nextLine}' and continue in processing")
+                    }
                 }
+
+                linesCount++
             }
 
-            linesCount++
+        }
+        finally {
+            reader.close()
         }
 
         listener.onFileProcessed(file)


### PR DESCRIPTION
After importing completed, the file was never renamed from ".processing" to ".imported".
The ES log showed an error similar to: "can't rename file x.processing to x.processing.imported".
When manually attempting to rename the file through the OS, the OS would report it was unable to.

The file could not be renamed because it was still open.
The solution that worked for me was to add a reader.close() to close the CSVReader after the file has imported.