### PR TITLE
Add a 'row_filter' option to be able to filter rows based on field values

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ The CSV river import data from CSV files and index it.
             "field_timestamp" : "imported_at",
             "concurrent_requests" : "1",
             "charset" : "UTF-8",
+            "row_filter" : {
+                "column1" : "Value Match",
+                "column2" : "!Exclude Value Match",
+                "column3" : "/RegEx Match/"
+                "column4" : "!/Exclude RegEx Match/"
+	        },
             "script_before_all": "/path/to/before_all.sh",
             "script_after_all": "/path/to/after_all.sh",
             "script_before_file": "/path/to/before_file.sh",

--- a/src/main/groovy/org/agileworks/elasticsearch/river/csv/Configuration.groovy
+++ b/src/main/groovy/org/agileworks/elasticsearch/river/csv/Configuration.groovy
@@ -42,6 +42,8 @@ class Configuration {
 
     Charset charset = Charset.forName('UTF-8')
 
+    Map<String, Object> rowFilter
+
     Configuration(RiverSettings settings, String riverName) {
 
         if (settings.settings().containsKey(Constants.CSV_FILE)) {
@@ -84,6 +86,8 @@ UTF-16      Sixteen-bit UCS Transformation Format, byte order identified by an o
 More details about charsets are available at http://docs.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html
 """)
             }
+
+            rowFilter = (Map<String, Object>) csvSettings.get(Constants.CSV.ROW_FILTER)
 
             scriptBeforeAll = nodeStringValue(csvSettings.get(Constants.CSV.SCRIPT_BEFORE_ALL), null)
             scriptAfterAll = nodeStringValue(csvSettings.get(Constants.CSV.SCRIPT_AFTER_ALL), null)

--- a/src/main/groovy/org/agileworks/elasticsearch/river/csv/Constants.groovy
+++ b/src/main/groovy/org/agileworks/elasticsearch/river/csv/Constants.groovy
@@ -33,6 +33,8 @@ class Constants {
 
         static final String CONCURRENT_REQUESTS = 'concurrent_requests'
 
+        static final String ROW_FILTER = 'row_filter'
+
         static final String SCRIPT_BEFORE_ALL = 'script_before_all'
         static final String SCRIPT_AFTER_ALL = 'script_after_all'
         static final String SCRIPT_BEFORE_FILE = 'script_before_file'

--- a/src/test/groovy/org/agileworks/elasticsearch/river/csv/ConfigurationTest.groovy
+++ b/src/test/groovy/org/agileworks/elasticsearch/river/csv/ConfigurationTest.groovy
@@ -85,5 +85,6 @@ class ConfigurationTest extends Specification {
         config.quoteCharacter
         config.separator
         config.typeName
+        !config.rowFilter
     }
 }


### PR DESCRIPTION
This adds a 'row_filter' option that will include or exclude rows based on what a particular field value is.

If a field value matches the row_filter, the row is included, unless the row_filter is prefixed with '!', in which case the row is excluded.

If the row_filter is prefixed and suffixed with '/', then it is treated as a RegEx match rather than an exact value match.

If multiple fields are used in row_filter, it is treated as an AND, and all fields must match for the row to be included.

If row_filter is omitted, it does not impact performance.
If row_filter is used, it probably impacts performance, but I haven't noticed a significant difference.
The row_filter code performance probably can be improved by doing some steps only once per field rather than every time a row is processed.