### PR TITLE
For security reasons, limit which folders scripts are allowed to run from

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ The CSV river import data from CSV files and index it.
         #!/bin/bash
         echo "greetings from shell after all, processed $*"
 
+####To limit what folders scripts are allowed to run from:
+
+Create an "immutable-settings.json" file in the plugins/river-csv folder with content similar to this:
+
+    {
+        "allowed_script_folders" : [
+            "/Path/To/Scripts/Folder/1/",
+            "/Path/To/Scripts/Folder/2/"
+        ]
+    }
+
+Scripts that are not in the listed folders or one of its subfolders will not be allowed to run.
 
 ###Optional parameters:
 


### PR DESCRIPTION
Currently, it appears to me that the script_before_all, script_after_all, script_before_file and script_after_file settings are not restricted in any way.

I imagine that if someone didn't have access to the ES server, but did have the ability to send ES remote commands, then they could possibly configure a CSV river with the import folder and scripts settings pointed to another workstation or server.
At this point the attacker could run any command remotely by way of the configured scripts.

This change will allow restrictions to what folders scripts are allowed to run from.
This is done by creating a local config file that specifies the allowed folders.
These allowed folders cannot be configured remotely through ES, so that an attacker cannot change it without having access to the ES server.

By default the local config file does not exist, in order to preserve current behavior, this is interpreted as not having folder restrictions on scripts.