### PR TITLE
Add support for Elasticsearch 1.5.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If it doesn't work, clone git repository and build plugin manually.
     -------------------------------------
     | CSV Plugin     | ElasticSearch    |
     -------------------------------------
-    | master         | 1.4.x -> master  |
+    | master         | 1.5.x -> master  |
     -------------------------------------
     | 2.1.1          | 1.4.x -> master  |
     -------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <java.version>1.6</java.version>
 
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
-        <groovy.version>2.3.2</groovy.version>
+        <groovy.version>2.4.0</groovy.version>
         <groovy.eclipse.compiler.version>2.8.0-01</groovy.eclipse.compiler.version>
         <groovy-eclipse-batch.version>2.1.8-01</groovy-eclipse-batch.version>
         <spock.version>0.7-groovy-2.0</spock.version>


### PR DESCRIPTION
Change to make the river function on ES 1.5.0.
With this change, it will no longer function on ES 1.4.x.