### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 CSV River Plugin for ElasticSearch
 ==================================
 
-#Important notice
+# Important notice
 
 As from ES version 2 and above, rivers are not supported anymore. This said we've discontinued this repo for active development and let it be only for important fixes.
 
-#New ElasticSearch CSV application
+# New ElasticSearch CSV application
 
 We've staretd development on new standalone version of CSV uploader: https://github.com/AgileWorksOrg/elasticsearch-csv
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
